### PR TITLE
removed v0.6.0 package

### DIFF
--- a/package-feed.xml
+++ b/package-feed.xml
@@ -31,16 +31,6 @@
       <pubDate>Sat, 11 Nov 2023 12:47:07 UTC</pubDate>
     </item>
     <item>
-      <title>de.netzwerk-universitaetsmedizin.ebm-cpg#0.6.0</title>
-      <description>de.netzwerk-universitaetsmedizin.ebm-cpg</description>
-      <link>https://github.com/CEOsys/cpg-on-ebm-on-fhir/releases/download/v0.6.0/ebm-cpg.netzwerk-universitaetsmedizin.de-0.6.0.tgz?raw=true</link>
-      <guid isPermaLink="true">https://github.com/CEOsys/cpg-on-ebm-on-fhir/releases/download/v0.6.0/ebm-cpg.netzwerk-universitaetsmedizin.de-0.6.0.tgz?raw=true</guid>
-      <dc:creator>glichtner</dc:creator>
-      <fhir:version>5.0.0</fhir:version>
-      <fhir:kind>IG</fhir:kind>
-      <pubDate>Sat, 11 Nov 2023 12:47:07 UTC</pubDate>
-    </item>
-    <item>
       <title>de.netzwerk-universitaetsmedizin.ceosys.template#0.1.0</title>
       <description>de.netzwerk-universitaetsmedizin.ceosys.template</description>
       <link>https://github.com/CEOsys/ig-template-ceosys/releases/download/v0.1.0/package.tar.gz?raw=true</link>


### PR DESCRIPTION
removed v0.6.0 package


Because of (https://chat.fhir.org/#narrow/stream/328836-tooling.2FPackage-Crawlers/topic/stream.20events/near/432689847):

Processing meta feed entry: University Medicine Greifswald - Department of Anesthesia, Intensive Care, Emergency and Pain Medicine
Processing: https://github.com/umg-minai/fhir-package-feed/blob/main/package-feed.xml?raw=true

Downloading package: de.netzwerk-universitaetsmedizin.ebm-cpg version: 0.6.0 Error: The name of the package 'ebm-cpg.netzwerk-universitaetsmedizin.de' does not match the name in the feed 'de.netzwerk-universitaetsmedizin.ebm-cpg' Feed University Medicine Greifswald - Department of Anesthesia, Intensive Care, Emergency and Pain Medicine processed.